### PR TITLE
Fixed issue with partial scrolling when using FixedExtendScrollContro…

### DIFF
--- a/lib/clickable_list_wheel_widget.dart
+++ b/lib/clickable_list_wheel_widget.dart
@@ -88,7 +88,9 @@ class _ClickableListWheelScrollViewState
   }
 
   int _getClickedIndex() {
-    final currentIndex = widget.scrollController.offset ~/ widget.itemHeight;
+    final currentIndex = (widget.scrollController is FixedExtentScrollController) ?
+                          (widget.scrollController as FixedExtentScrollController).selectedItem :
+                           widget.scrollController.offset ~/ widget.itemHeight;
     final clickOffset = _getClickedOffset();
     final indexOffset = (clickOffset / widget.itemHeight).round();
     final newIndex = currentIndex + indexOffset;


### PR DESCRIPTION
Previously when using this widget with FixedExtendScrollPhysics and partially scrolling to an item, not enough for the app to snap to it, then tapping the current item the ListWheelScrollView would incorrectly animate to the item that was partially scrolled to. Now, whenever the user partially scrolls to another widget and then taps on the currently selected widget, the app will recognise that the currently selected widget was tapped.
**Before fix:**
![partialscroll](https://user-images.githubusercontent.com/52672507/166451320-f8bf8126-2f74-426a-b2ce-c9be6d288fd6.gif)
**After fix:**
![partialScrollFix](https://user-images.githubusercontent.com/52672507/166452256-b2403684-0ebd-49a8-bdb4-598ea1502bd8.gif)

It may be difficult to understand what is going on here but essentially in the first gif I partially scroll to another widget then tap on the current widget leading to the app incorrectly moving to the widget above or below. In the second gif I do the same however this time when tapping on the current widget, the app correctly recognises which widget was tapped.