### PR TITLE
Fixing bugs with "ListWheelChildLoopingListDelegate"

### DIFF
--- a/lib/clickable_list_wheel_widget.dart
+++ b/lib/clickable_list_wheel_widget.dart
@@ -98,14 +98,12 @@ class _ClickableListWheelScrollViewState
     final clickOffset = _getClickedOffset();
     final indexOffset = (clickOffset / widget.itemHeight).round();
     final newIndex = currentIndex + indexOffset;
-
-    if (newIndex < 0 || newIndex >= widget.itemCount) {
-      return -1;
-    }
-
     if (widget.loop) {
       return newIndex % widget.itemCount;
     } else {
+        if (newIndex < 0 || newIndex >= widget.itemCount) {
+          return -1;
+        }
       return newIndex;
     }
   }

--- a/lib/clickable_list_wheel_widget.dart
+++ b/lib/clickable_list_wheel_widget.dart
@@ -49,8 +49,7 @@ class ClickableListWheelScrollView extends StatefulWidget {
   State<StatefulWidget> createState() => _ClickableListWheelScrollViewState();
 }
 
-class _ClickableListWheelScrollViewState
-    extends State<ClickableListWheelScrollView> {
+class _ClickableListWheelScrollViewState extends State<ClickableListWheelScrollView> {
   double? _listHeight;
   Offset? _tapUpDetails;
 
@@ -92,18 +91,18 @@ class _ClickableListWheelScrollViewState
   }
 
   int _getClickedIndex() {
-    final currentIndex = (widget.scrollController is FixedExtentScrollController) ?
-                          (widget.scrollController as FixedExtentScrollController).selectedItem :
-                           widget.scrollController.offset ~/ widget.itemHeight;
+    final currentIndex = (widget.scrollController is FixedExtentScrollController)
+        ? (widget.scrollController as FixedExtentScrollController).selectedItem
+        : widget.scrollController.offset ~/ widget.itemHeight;
     final clickOffset = _getClickedOffset();
     final indexOffset = (clickOffset / widget.itemHeight).round();
     final newIndex = currentIndex + indexOffset;
     if (widget.loop) {
       return newIndex % widget.itemCount;
     } else {
-        if (newIndex < 0 || newIndex >= widget.itemCount) {
-          return -1;
-        }
+      if (newIndex < 0 || newIndex >= widget.itemCount) {
+        return -1;
+      }
       return newIndex;
     }
   }
@@ -124,8 +123,8 @@ class _ClickableListWheelScrollViewState
     widget.onItemTapCallback?.call(index);
 
     if (widget.scrollOnTap) {
-      await widget.scrollController.animateTo(index * widget.itemHeight,
-          duration: widget.animationDuration, curve: Curves.ease);
+      await widget.scrollController
+          .animateTo(index * widget.itemHeight, duration: widget.animationDuration, curve: Curves.ease);
     }
   }
 
@@ -139,6 +138,17 @@ class _ClickableListWheelScrollViewState
     widget.onItemTapCallback?.call(index);
 
     if (widget.scrollOnTap) {
+      if (widget.loop) {
+        final offset = _getClickedOffset();
+        final scrollOffset = widget.scrollController.offset + offset;
+        final index = (scrollOffset / widget.itemHeight).round();
+        (widget.scrollController as FixedExtentScrollController).animateToItem(
+          index,
+          duration: widget.animationDuration,
+          curve: Curves.ease,
+        );
+        return;
+      }
       (widget.scrollController as FixedExtentScrollController).animateToItem(
         index,
         duration: widget.animationDuration,


### PR DESCRIPTION
Hello, current version of this repository does not work properly when using looping lists (ListWheelChildLoopingListDelegate) . I've fixed two separate bugs.
- [b131f73](https://github.com/Cilestal/clickable_list_wheel_view/commit/b131f736be7c313fe267acf44d879dcd26c2c2b5) Fixes indexing for looping lists. Without the fix only the main "loop" of variables respond to touch. The logic was fine, only the check for index < 0 was made too early. I've only moved around the logic.
- [83377b2](https://github.com/Cilestal/clickable_list_wheel_view/commit/83377b27a01fc48e7b442763695d00ccbeaecff0) Fixes tap on scrolling behavior, where tapping on the items from another "loop" would scroll to the item on the "main loop", in the example code that would be pressing on 9 on the start would cause the widget to scroll down to 9 instead of scrolling up to 9.

Minimal code Example used to test everything : 
```

import 'package:clickable_list_wheel_view/clickable_list_wheel_widget.dart';
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: Material(
        child: MyHomePage(),
      ),
    );
  }
}


class MyHomePage extends StatelessWidget {
  final _scrollController = FixedExtentScrollController();

  static const double _itemHeight = 60;
  static const int _itemCount = 10;
  final List<Widget> _list = List.generate(10, (index) => Text("$index"));
  @override
  Widget build(BuildContext context) {
    return Expanded(
      child: ClickableListWheelScrollView(
        scrollController: _scrollController,
        itemHeight: _itemHeight,
        itemCount: _itemCount,
        scrollOnTap: true,
        onItemTapCallback: (index) {
          print("onItemTapCallback index: $index");
        },
        loop: true,
        child: ListWheelScrollView.useDelegate(
          controller: _scrollController,
          itemExtent: _itemHeight,
          physics: FixedExtentScrollPhysics(),
          overAndUnderCenterOpacity: 0.5,
          perspective: 0.002,
          onSelectedItemChanged: (index) {
            print("onSelectedItemChanged index: $index");
          },
          childDelegate: ListWheelChildLoopingListDelegate(children: _list),
        ),
      ),
    );
  }
}



```